### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -5,6 +5,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LtiLibrary/LtiAdvantage/security/code-scanning/1](https://github.com/LtiLibrary/LtiAdvantage/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow. The best practice is to set it at the workflow level (top-level, just after `name` and `on`), so it applies to all jobs unless overridden. For the `dorny/test-reporter` action, the minimal required permissions are `contents: read` (to download artifacts) and `checks: write` (to create/update check runs). Add the following block after the `on:` section:

```yaml
permissions:
  contents: read
  checks: write
```

No other changes are needed. This does not affect existing functionality and follows the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
