### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/LtiLibrary/LtiAdvantage/security/code-scanning/2](https://github.com/LtiLibrary/LtiAdvantage/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/dotnet-core.yml`. The block should be placed at the root level (before `jobs:`) to apply to all jobs unless overridden. The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not write to them. If any steps require additional permissions (e.g., to create releases or modify issues), those can be added as needed, but for this workflow, `contents: read` is sufficient. The change should be made by inserting the following lines after the workflow `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
