### PR TITLE
Update test-report GHA dorny/test-reporter@v1 -> v3 

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -13,7 +13,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-    - uses: dorny/test-reporter@v1
+    - uses: dorny/test-reporter@v3
       with:
         artifact: test-results            # artifact name
         name: XUnit Tests                  # Name of the check run which will be created


### PR DESCRIPTION
Upgrade dorny/test-reporter@v1 -> v3 so it runs on a supported Node JS version.

Completely untested I am afraid.